### PR TITLE
Add ansible-test dependencies to enable sanity checks

### DIFF
--- a/ansible-core/debian-bookworm-slim/Dockerfile
+++ b/ansible-core/debian-bookworm-slim/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/ansible-core/debian-bookworm/Dockerfile
+++ b/ansible-core/debian-bookworm/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/ansible-core/debian-trixie-slim/Dockerfile
+++ b/ansible-core/debian-trixie-slim/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/ansible-core/debian-trixie/Dockerfile
+++ b/ansible-core/debian-trixie/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/ansible-core/rockylinux-10/Dockerfile
+++ b/ansible-core/rockylinux-10/Dockerfile
@@ -12,6 +12,14 @@ LABEL maintainer="will@willhallonline.co.uk" \
 
 RUN dnf -y install systemd systemd-libs dbus && \
     dnf clean all && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     (cd /lib/systemd/system/sysinit.target.wants/ && \
         for i in *; do [ "$i" = "systemd-tmpfiles-setup.service" ] || rm -f "$i"; done) && \

--- a/ansible-core/ubuntu-22.04/Dockerfile
+++ b/ansible-core/ubuntu-22.04/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/ansible-core/ubuntu-24.04/Dockerfile
+++ b/ansible-core/ubuntu-24.04/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \

--- a/ansible-core/ubuntu-26.04/Dockerfile
+++ b/ansible-core/ubuntu-26.04/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous && \
     # Remove unnecessary systemd services
     rm -f /lib/systemd/system/multi-user.target.wants/* && \
     rm -f /etc/systemd/system/*.wants/* && \


### PR DESCRIPTION
## Summary

Fixes #1 by adding Python packages required for `ansible-test sanity` to work.

The issue reported that running `ansible-test sanity` inside the containers failed with "No module named pycodestyle". This PR adds all the necessary testing dependencies that ansible-test expects.

## Changes

Added the following Python packages to all test Dockerfiles (Debian/Ubuntu and Rocky Linux):
- **pycodestyle** - PEP 8 style checking
- **pytest** - Testing framework
- **pytest-mock** - Mocking support for pytest
- **yamllint** - YAML linting
- **rstcheck** - reStructuredText validation
- **pathspec** - Pattern matching for ignore files
- **voluptuous** - Validation library

These packages are installed via pip3 in all 8 Dockerfiles (Debian Bookworm/Trixie, Ubuntu 22.04/24.04/26.04, Rocky Linux 10).

## Testing

The image now includes all dependencies needed for:
```bash
docker run -it -v $PWD:/opt/code --rm willhallonline/ansible-test:latest
# Inside container:
cd /opt/code
ansible-test sanity
```