### PR TITLE
Add ansible-test sanity dependencies to Dockerfiles

### DIFF
--- a/ansible-core/debian-bookworm-slim/Dockerfile
+++ b/ansible-core/debian-bookworm-slim/Dockerfile
@@ -26,6 +26,16 @@ RUN apt-get update && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]

--- a/ansible-core/debian-bookworm/Dockerfile
+++ b/ansible-core/debian-bookworm/Dockerfile
@@ -26,6 +26,16 @@ RUN apt-get update && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]

--- a/ansible-core/debian-trixie-slim/Dockerfile
+++ b/ansible-core/debian-trixie-slim/Dockerfile
@@ -26,6 +26,16 @@ RUN apt-get update && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]

--- a/ansible-core/debian-trixie/Dockerfile
+++ b/ansible-core/debian-trixie/Dockerfile
@@ -26,6 +26,16 @@ RUN apt-get update && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]

--- a/ansible-core/rockylinux-10/Dockerfile
+++ b/ansible-core/rockylinux-10/Dockerfile
@@ -23,6 +23,16 @@ RUN dnf -y install systemd systemd-libs dbus && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]

--- a/ansible-core/ubuntu-22.04/Dockerfile
+++ b/ansible-core/ubuntu-22.04/Dockerfile
@@ -26,6 +26,16 @@ RUN apt-get update && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]

--- a/ansible-core/ubuntu-24.04/Dockerfile
+++ b/ansible-core/ubuntu-24.04/Dockerfile
@@ -26,6 +26,16 @@ RUN apt-get update && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]

--- a/ansible-core/ubuntu-26.04/Dockerfile
+++ b/ansible-core/ubuntu-26.04/Dockerfile
@@ -26,6 +26,16 @@ RUN apt-get update && \
     rm -f /lib/systemd/system/basic.target.wants/* && \
     rm -f /lib/systemd/system/anaconda.target.wants/*
 
+# Install Python packages required for ansible-test sanity checks.
+RUN pip3 install --no-cache-dir \
+        pycodestyle \
+        pytest \
+        pytest-mock \
+        yamllint \
+        rstcheck \
+        pathspec \
+        voluptuous
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
## Summary
Adds the Python packages required for `ansible-test sanity` to run successfully inside the test images.

Installed via `pip3` in a single `RUN` command after the base OS/systemd packages, in every Dockerfile under `ansible-core/`:
- pycodestyle
- pytest
- pytest-mock
- yamllint
- rstcheck
- pathspec
- voluptuous

Verified locally by building the `debian-bookworm` and `rockylinux-10` images and confirming all packages import successfully.

Fixes #1