### PR TITLE
Add CHANGELOG, CONTRIBUTING, and links to parent docker-ansible project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## Version Alignment
+
+This project tracks the same versions as [docker-ansible](https://github.com/willhallonline/docker-ansible). See that project's [CHANGELOG](https://github.com/willhallonline/docker-ansible/blob/main/CHANGELOG.md) for detailed version history.
+
+## ansible-test Specific Changes
+
+### v6.4.1
+- Inherit: Fix collection paths for Ubuntu 26.04 from docker-ansible #166
+- Add ansible-test dependencies for sanity checks (#1)
+
+### v6.4.0
+- Inherit: Added Ansible 2.21.0 support from docker-ansible
+- Added ansible-test dependencies (pycodestyle, pytest, yamllint, rstcheck, etc.) for full ansible-test sanity support
+- GitHub Actions workflow for matrix builds (Debian, Ubuntu, Rocky Linux)
+- Added systemd support across all test images
+
+### v6.3.0 → v6.0.0
+- Modernized from Ansible 2.9/2.10 (end-of-life) to Ansible 2.16–2.21
+- Replaced GitLab CI with GitHub Actions
+- Added multi-architecture support (amd64, arm64)
+- Removed obsolete OS bases: CentOS 7/8, Ubuntu 18.04/20.04, Debian Stretch/Buster
+- Added modern OS bases: Debian Bookworm/Trixie, Ubuntu 22.04/24.04/26.04, Rocky Linux 10
+- Improved README with molecule integration examples and CI/CD guidance
+
+### Previous Versions
+Previous versions of ansible-test (supporting Ansible 2.9/2.10) are archived and no longer maintained. Use v6.0.0+ for current Ansible versions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Ansible Testing Docker Container Project
+
+Thank you for considering contributing to the project! I appreciate your time and effort and value your input. The aims of this file are to try to make it easier to contribute and I am happy to try and support contributions. Please bear in mind that the overall aims are to support testing of Ansible roles and playbooks across different OS versions and architectures.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+1. **Check Current Issues**: Before you create a new issue, please search for similar issues in the [Issue Tracker](https://github.com/willhallonline/docker-ansible-test/issues).
+2. **Create a New Issue**: If your issue is new, please include:
+   - **Title**: A succinct title that describes the issue.
+   - **Description**: A detailed description, including steps to reproduce, and environment details (e.g., OS version, Docker version, Ansible version).
+   - **Logs and Error Messages**: Any relevant logs or error messages from `ansible-test` or container operations.
+
+### Suggesting Features
+
+If you have an idea to improve the project, submit a feature request in the [Issue Tracker](https://github.com/willhallonline/docker-ansible-test/issues) and I'll try to respond.
+
+### Submitting Pull Requests
+
+1. **Fork the Repository**: Create a fork of the repository on GitHub.
+2. **Clone Your Fork**: 
+
+   ```bash
+   git clone https://github.com/your-username/docker-ansible-test.git
+   cd docker-ansible-test
+   ```
+
+3. **Create a Branch**:
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+4. **Make Changes**: Develop your feature or fix in your local repository.
+   - Changes to Dockerfiles should maintain consistency across all OS bases
+   - Test locally: `docker build --build-arg ANSIBLE_TAG=2.21-debian-trixie -t test:local ansible-core/debian-trixie/`
+
+5. **Commit Changes**:
+
+   ```bash
+   git add .
+   git commit -m "Description of your changes"
+   ```
+
+6. **Push Changes**:
+
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+7. **Open a Pull Request**: Go to the repository on GitHub and open a pull request. Fill out the template provided, if available.
+
+### Code Style and Testing
+
+- **Follow Best Practices**: Ensure your code follows best practices for Dockerfiles.
+- **Testing**: Thoroughly test your changes locally:
+  - Build the image: `docker build --build-arg ANSIBLE_TAG=<version>-<os> -t test:local ansible-core/<os>/`
+  - Run sanity checks: `docker run --rm test:local python3 -m pycodestyle --version`
+  - Test with ansible-test: `docker run --rm -v /path/to/collection:/opt/code test:local ansible-test sanity`
+- **Documentation**: Update the README.md or CHANGELOG.md if your changes affect users.
+- **Consistency**: Keep changes aligned with the parent [docker-ansible](https://github.com/willhallonline/docker-ansible) project structure.
+
+### Reviewing and Approval
+
+I make every effort to review pull requests promptly, but sometimes I may be busy or a request may be overlooked, so kindly ask for your patience during the process.
+
+## Relationship to docker-ansible
+
+This project extends [docker-ansible](https://github.com/willhallonline/docker-ansible) with systemd support for role and playbook testing. Changes that affect Ansible versions or base OS support should be coordinated with the parent project's releases.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Docker images with **systemd** enabled for testing Ansible roles and playbooks inside containers. These images extend [willhallonline/ansible](https://github.com/willhallonline/docker-ansible) with systemd support, making them ideal for CI/CD testing of roles that manage services or interact with the init system.
 
+**Version Alignment:** ansible-test versions track [docker-ansible](https://github.com/willhallonline/docker-ansible) releases. Both projects support the same Ansible Core versions (2.16–2.21) and base OS combinations.
+
 [![Docker Pulls](https://img.shields.io/docker/pulls/willhallonline/ansible-test "Docker Pulls")][hub] ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/willhallonline/ansible-test/latest)
 
 ## Current Ansible Core Versions
 
-These are the latest Ansible Core versions running within the containers:
+These are the latest Ansible Core versions running within the containers. **Versions match [docker-ansible](https://github.com/willhallonline/docker-ansible):**
 
 - Ansible 2.16: 2.16.14
 - Ansible 2.17: 2.17.14
@@ -14,6 +16,8 @@ These are the latest Ansible Core versions running within the containers:
 - Ansible 2.19: 2.19.2
 - Ansible 2.20: 2.20.0
 - Ansible 2.21: 2.21.0
+
+See [CHANGELOG.md](CHANGELOG.md) for version history and [docker-ansible CHANGELOG](https://github.com/willhallonline/docker-ansible/blob/main/CHANGELOG.md) for detailed release notes.
 
 ## Supported tags and respective `Dockerfile` links
 
@@ -149,5 +153,8 @@ docker exec <container-id> ansible-playbook /ansible/playbook.yml
 ## Maintainer
 
 - Written and maintained by [Will Hall](https://www.willhallonline.co.uk)
+- Part of the [docker-ansible](https://github.com/willhallonline/docker-ansible) project family
+
+For contributing guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 [hub]: https://hub.docker.com/r/willhallonline/ansible-test


### PR DESCRIPTION
## Summary

Add project documentation and establish clear linkage to the parent [docker-ansible](https://github.com/willhallonline/docker-ansible) project.

## Changes

### New Files

#### CHANGELOG.md
- Documents version alignment with docker-ansible (v6.0.0+)
- Lists ansible-test specific changes including:
  - ansible-test dependencies for sanity checks
  - GitHub Actions CI/CD migration
  - Modernization to Ansible 2.16–2.21
  - Systemd support across all test images
- Links to parent project's detailed CHANGELOG

#### CONTRIBUTING.md
- Guidelines for reporting bugs and suggesting features
- PR submission process with local testing instructions
- Code style and testing best practices
- Explains relationship to docker-ansible parent project

### Updated Files

#### README.md
- Added "Version Alignment" note explaining versions track docker-ansible
- Updated Ansible Core versions section with explicit parent project reference
- Links to CHANGELOG.md for version history
- Links to CONTRIBUTING.md for contribution guidelines
- Updated maintainer section to note docker-ansible project family

## Rationale

These changes provide:
- Clear version tracking to the parent project
- Contribution guidelines for the community
- Transparency about project maintenance and compatibility
- Easier onboarding for contributors