### PR TITLE
Add Dependabot configuration for Docker and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,120 @@
+version: 2
+updates:
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/debian-bookworm"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/debian-bookworm-slim"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/debian-trixie"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/debian-trixie-slim"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/rockylinux-10"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/ubuntu-22.04"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/ubuntu-24.04"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ansible-core/ubuntu-26.04"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "willhallonline"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Overview
Adds automated dependency management via Dependabot to monitor and update:
- **Docker base images** across all 8 ansible-core Dockerfiles
- **GitHub Actions** workflow versions

## Configuration
- **Schedule**: Weekly on Mondays at 08:00 UTC
- **PR Limits**: Up to 10 open PRs per ecosystem to maintain a manageable workflow
- **Labels**: All PRs tagged with 'dependencies' and ecosystem type for easy filtering
- **Reviewer**: Auto-assigned to @willhallonline

## Benefits
- Keeps Docker base images up-to-date with security patches
- Ensures GitHub Actions stay current
- Automated PRs make dependency management effortless
- Clear labeling for easy tracking

This enables Dependabot on the repository and requires no additional setup.