### PR TITLE
Fix pip3 PEP 668 externally-managed-environment error on ubuntu-24.04/26.04

### DIFF
--- a/ansible-core/ubuntu-24.04/Dockerfile
+++ b/ansible-core/ubuntu-24.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip3 install --no-cache-dir \
+    pip3 install --no-cache-dir --break-system-packages \
         pycodestyle \
         pytest \
         pytest-mock \

--- a/ansible-core/ubuntu-26.04/Dockerfile
+++ b/ansible-core/ubuntu-26.04/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
         dbus && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip3 install --no-cache-dir \
+    pip3 install --no-cache-dir --break-system-packages \
         pycodestyle \
         pytest \
         pytest-mock \


### PR DESCRIPTION
## Why builds were failing

Investigated recent "Ansible Test Matrix Build" runs:

1. **Missing DockerHub credentials** (already resolved by repo owner adding `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`) caused `docker/login-action` to fail with "Username and password required" on every job for `push`/`workflow_dispatch` events.
2. **`ubuntu-24.04` and `ubuntu-26.04` jobs still fail** after the credentials fix, with:
   ```
   error: externally-managed-environment
   ...pass --break-system-packages
   ```
   These two base images (`willhallonline/ansible:*-ubuntu-24.04` / `*-ubuntu-26.04`) ship the OS-managed `pip3` (installed under `/usr/lib/python3/dist-packages`), which enforces PEP 668 and blocks `pip3 install` outside a venv. Every other base image (debian-bookworm/trixie, rockylinux-10, ubuntu-22.04) uses a pip installed to `/usr/local`, so they don't hit this restriction.

## Fix

Added `--break-system-packages` to the `pip3 install` step in `ansible-core/ubuntu-24.04/Dockerfile` and `ansible-core/ubuntu-26.04/Dockerfile`. Verified locally with `docker build --platform linux/amd64` for both — installs succeed.

## Known separate issue (not fixed here, needs upstream)

All `willhallonline/ansible:*-ubuntu-24.04` tags (2.16–2.21) currently only publish an `amd64` manifest — no `arm64` variant exists on Docker Hub, even though the upstream `docker-ansible` repo's README states ARM64 is available for all images. This causes `buildx` (which requests `linux/amd64,linux/arm64`) to fail with `no match for platform in manifest` for every `ubuntu-24.04` matrix entry. That's a base-image publishing gap in the `willhallonline/docker-ansible` repo, not something this repo's Dockerfile can fix — flagging for follow-up there.