### PR TITLE
Test container only after successful push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
             ANSIBLE_TAG=${{ matrix.tag-version }}-${{ matrix.os }}
 
       - name: Test docker image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'willhallonline/docker-ansible-test' && steps.build.outputs.digest }}
         shell: bash
         run: |
           docker run --rm --privileged \


### PR DESCRIPTION
## Description
Ensure the test step only tries to run Docker containers that exist and were successfully pushed to the registry.

## Problem
The workflow attempted to test containers even when:
- The build/push may not have completed successfully
- The image may not be available in the registry yet
- Using multi-platform builds, the local container may not exist

## Solution
Added stricter conditions to the test step to verify:
1. `github.event_name != 'pull_request'` — only when not a PR (image is pushed)
2. `github.repository == 'willhallonline/docker-ansible-test'` — correct repository
3. `steps.build.outputs.digest` — build completed successfully

This prevents failures from trying to run non-existent containers.

## Changes
- Updated `.github/workflows/build.yml` test step condition with additional checks