### PR TITLE
Fix ubuntu-24.04 build failures: restrict to linux/amd64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,18 +105,27 @@ jobs:
             tag-version: "2.17"
 
           # Ubuntu 24.04
+          # NOTE: willhallonline/ansible only publishes linux/amd64 for the
+          # ubuntu-24.04 base image (no arm64 manifest), so restrict platforms
+          # to avoid "no match for platform in manifest" build failures.
           - os: ubuntu-24.04
             tag-version: "2.16"
+            platforms: linux/amd64
           - os: ubuntu-24.04
             tag-version: "2.17"
+            platforms: linux/amd64
           - os: ubuntu-24.04
             tag-version: "2.18"
+            platforms: linux/amd64
           - os: ubuntu-24.04
             tag-version: "2.19"
+            platforms: linux/amd64
           - os: ubuntu-24.04
             tag-version: "2.20"
+            platforms: linux/amd64
           - os: ubuntu-24.04
             tag-version: "2.21"
+            platforms: linux/amd64
 
           # Ubuntu 26.04
           - os: ubuntu-26.04
@@ -167,7 +176,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: ./ansible-core/${{ matrix.os }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' && github.repository == 'willhallonline/docker-ansible-test' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

After the pip PEP 668 fix (#13) merged, every `ubuntu-24.04` matrix job (all Ansible versions 2.16–2.21) still fails with:

```
ERROR: failed to build: failed to solve: willhallonline/ansible:X-ubuntu-24.04: failed to resolve source metadata for docker.io/willhallonline/ansible:X-ubuntu-24.04: no match for platform in manifest: not found
```

Confirmed via `docker manifest inspect willhallonline/ansible:<version>-ubuntu-24.04` for all six supported versions — each only publishes an `amd64` image, with no `arm64` manifest. Every other base image in the matrix (debian-bookworm/trixie, rockylinux-10, ubuntu-22.04, ubuntu-26.04) does publish `arm64`, so buildx's default `linux/amd64,linux/arm64` request fails only for `ubuntu-24.04`.

This is an upstream publishing gap in `willhallonline/ansible`, not something fixable from this repo's Dockerfile.

## Fix

Added a per-matrix-entry `platforms` field, defaulting to `linux/amd64,linux/arm64` but overridden to `linux/amd64` for all `ubuntu-24.04` entries. The build step now uses `${{ matrix.platforms || 'linux/amd64,linux/arm64' }}`.

## Verification

Triggered a fresh `workflow_dispatch` run after pushing — monitoring for completion.